### PR TITLE
WIP: Loads template via S3 to bypass length limit

### DIFF
--- a/src/environmentbase/environmentbase.py
+++ b/src/environmentbase/environmentbase.py
@@ -168,7 +168,7 @@ class EnvironmentBase(object):
             notification_arns.append(sns_topic.arn)
 
         cfn_template = self._load_template()
-        stack_url = self.upload_template(json.loads(cfn_template))
+        stack_url = self.upload_template(pure_json.loads(cfn_template))
         cfn_conn = utility.get_boto_client(self.config, 'cloudformation')
         try:
             cfn_conn.update_stack(

--- a/src/environmentbase/environmentbase.py
+++ b/src/environmentbase/environmentbase.py
@@ -172,9 +172,10 @@ class EnvironmentBase(object):
         cfn_template = self._load_template()
         cfn_conn = utility.get_boto_client(self.config, 'cloudformation')
         try:
+            stack_url = self.upload_template(template)
             cfn_conn.update_stack(
                 StackName=stack_name,
-                TemplateBody=cfn_template,
+                TemplateURL=stack_url,
                 Parameters=stack_params,
                 NotificationARNs=notification_arns,
                 Capabilities=['CAPABILITY_IAM'])

--- a/src/environmentbase/environmentbase.py
+++ b/src/environmentbase/environmentbase.py
@@ -168,7 +168,9 @@ class EnvironmentBase(object):
             notification_arns.append(sns_topic.arn)
 
         cfn_template = self._load_template()
-        stack_url = self.upload_template(pure_json.loads(cfn_template))
+        template_json = pure_json.loads(cfn_template)
+        template_json.name = stack_name
+        stack_url = self.upload_template(template_json)
         cfn_conn = utility.get_boto_client(self.config, 'cloudformation')
         try:
             cfn_conn.update_stack(

--- a/src/environmentbase/environmentbase.py
+++ b/src/environmentbase/environmentbase.py
@@ -116,6 +116,15 @@ class EnvironmentBase(object):
             reloaded_template = pure_json.loads(raw_json)
             pure_json.dump(reloaded_template, output_file, indent=4, separators=(',', ':'))
 
+        stack_url = self.upload_template(self.template)
+        url_file_path = self._ensure_template_dir_exists('main_template_url')
+        with open(url_file_path, 'w') as url_file:
+            url_file.write(stack_url)
+            
+    def _load_template_stack_url(self):
+        url_file_path = self._ensure_template_dir_exists('main_template_url')
+        return open(url_file_path).readline().rstrip('\n')
+
     def estimate_cost(self, template_name=None, stack_params=None):
         template_body = self._load_template(template_name)
         # Get url to cost estimate calculator
@@ -167,10 +176,7 @@ class EnvironmentBase(object):
         if sns_topic:
             notification_arns.append(sns_topic.arn)
 
-        cfn_template = self._load_template()
-        template_json = pure_json.loads(cfn_template)
-        template_json.name = stack_name
-        stack_url = self.upload_template(template_json)
+        stack_url = self._load_template_stack_url()
         cfn_conn = utility.get_boto_client(self.config, 'cloudformation')
         try:
             cfn_conn.update_stack(

--- a/src/environmentbase/environmentbase.py
+++ b/src/environmentbase/environmentbase.py
@@ -170,9 +170,9 @@ class EnvironmentBase(object):
             notification_arns.append(sns_topic.arn)
 
         cfn_template = self._load_template()
+        stack_url = self.upload_template(json.loads(cfn_template))
         cfn_conn = utility.get_boto_client(self.config, 'cloudformation')
         try:
-            stack_url = self.upload_template(cfn_template)
             cfn_conn.update_stack(
                 StackName=stack_name,
                 TemplateURL=stack_url,
@@ -189,7 +189,7 @@ class EnvironmentBase(object):
             try:
                 cfn_conn.create_stack(
                     StackName=stack_name,
-                    TemplateBody=cfn_template,
+                    TemplateURL=stack_url,
                     Parameters=stack_params,
                     NotificationARNs=notification_arns,
                     Capabilities=['CAPABILITY_IAM'],

--- a/src/environmentbase/environmentbase.py
+++ b/src/environmentbase/environmentbase.py
@@ -172,7 +172,7 @@ class EnvironmentBase(object):
         cfn_template = self._load_template()
         cfn_conn = utility.get_boto_client(self.config, 'cloudformation')
         try:
-            stack_url = self.upload_template(template)
+            stack_url = self.upload_template(cfn_template)
             cfn_conn.update_stack(
                 StackName=stack_name,
                 TemplateURL=stack_url,

--- a/src/environmentbase/environmentbase.py
+++ b/src/environmentbase/environmentbase.py
@@ -155,8 +155,6 @@ class EnvironmentBase(object):
         if os.path.isfile(cfn_template_filename):
             with open(cfn_template_filename, 'r') as cfn_template_file:
                 cfn_template = cfn_template_file.read()
-            white_space = re.compile(r'\s+')
-            cfn_template = re.sub(white_space, ' ', cfn_template)
         else:
             raise ValueError('Template at: %s not found\n' % cfn_template_filename)
 


### PR DESCRIPTION
@rquiz @bigthyme This is (yet untested) change adds support for main stack template exceeding 51200 bytes. This is done by uploading the template to S3 bucket first and using the URL instead of passing the template directly.
